### PR TITLE
Use DialTLS instead of Dial

### DIFF
--- a/v1/backends/amqp.go
+++ b/v1/backends/amqp.go
@@ -314,7 +314,9 @@ func (amqpBackend *AMQPBackend) open(taskUUID string) (*amqp.Connection, *amqp.C
 	)
 
 	// Connect
-	conn, err = amqp.Dial(amqpBackend.config.ResultBackend)
+	// From amqp docs: DialTLS will use the provided tls.Config when it encounters an amqps:// scheme
+	// and will dial a plain connection when it encounters an amqp:// scheme.
+	conn, err = amqp.DialTLS(amqpBackend.config.Broker, amqpBackend.config.TLSConfig)
 	if err != nil {
 		return conn, channel, queue, nil, fmt.Errorf("Dial: %s", err)
 	}

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -200,7 +200,10 @@ func (amqpBroker *AMQPBroker) open() (*amqp.Connection, *amqp.Channel, amqp.Queu
 	)
 
 	// Connect
-	conn, err = amqp.Dial(amqpBroker.config.Broker)
+	// From amqp docs: DialTLS will use the provided tls.Config when it encounters an amqps:// scheme
+	// and will dial a plain connection when it encounters an amqp:// scheme.
+	conn, err = amqp.DialTLS(amqpBroker.config.Broker, amqpBroker.config.TLSConfig)
+
 	if err != nil {
 		return conn, channel, queue, nil, fmt.Errorf("Dial: %s", err)
 	}

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 
@@ -16,6 +17,7 @@ type Config struct {
 	ExchangeType    string `yaml:"exchange_type"`
 	DefaultQueue    string `yaml:"default_queue"`
 	BindingKey      string `yaml:"binding_key"`
+	TLSConfig       *tls.Config
 }
 
 // ReadFromFile reads data from a file


### PR DESCRIPTION
amqp makes adding TLS support fairly transparent–when using `amqp#DialTLS`, it will use the supplied `*tls.Config` depending on the scheme of the protocol: `amqps://` vs `amp://`.
